### PR TITLE
Add rel and target attributes for external links

### DIFF
--- a/app/views/job_postings/_listing.html.erb
+++ b/app/views/job_postings/_listing.html.erb
@@ -74,5 +74,9 @@
   </div>
 <% end %>
 
-<%= link_to "Apply Now", @job_posting.url,
-          class: "btn btn-sm btn-block my-5 btn-soft-primary transition-3d-hover" %>
+<%= link_to "Apply Now",
+  @job_posting.url,
+  class: "btn btn-sm btn-block my-5 btn-soft-primary transition-3d-hover",
+  target: "_blank",
+  rel: "noreferrer"
+%>

--- a/app/views/job_postings/show.html.erb
+++ b/app/views/job_postings/show.html.erb
@@ -42,7 +42,12 @@
                       <span class="fas fa-globe"></span>
                     </div>
                     <div class="media-body">
-                      <%= link_to @job_posting.company_host_url, @job_posting.company_url, class: "font-weight-medium", target: "_blank" %>
+                      <%= link_to @job_posting.company_host_url,
+                        @job_posting.company_url,
+                        class: "font-weight-medium",
+                        target: "_blank",
+                        rel: "noreferrer"
+                      %>
                       <small class="d-block text-secondary">Website</small>
                     </div>
                   </div>
@@ -86,8 +91,12 @@
                   </div>
                 <% end %>
 
-                <%= link_to "Apply Now", @job_posting.url,
-                      class: "btn btn-sm btn-block mt-5 btn-soft-primary transition-3d-hover" %>
+                <%= link_to "Apply Now",
+                  @job_posting.url,
+                  target: "_blank",
+                  rel: "noreferrer",
+                  class: "btn btn-sm btn-block mt-5 btn-soft-primary transition-3d-hover"
+                %>
               </div>
               <!-- End Content -->
             </div>


### PR DESCRIPTION
Adds `target="_blank"` and `rel="noreferrer"` to external links.

The `rel` attribute is required to fix a vulnerability with `target="_blank"` set on links.

For more information, check [this](https://developers.google.com/web/tools/lighthouse/audits/noopener) out.