### PR TITLE
Issue 756 - Replace nofollow with sponsored in the ad templates

### DIFF
--- a/app/views/ad_templates/@responsive_footer/show.html.erb
+++ b/app/views/ad_templates/@responsive_footer/show.html.erb
@@ -1,15 +1,15 @@
 <% cache_if @campaign.persisted? && @creative.persisted?, [@campaign, @creative] do %>
-<div id="cf">
-  <a data-href="campaign_url" class="cf-img-wrapper" target="_blank" rel="sponsored noopener">
+  <div id="cf">
+    <a data-href="campaign_url" class="cf-img-wrapper" target="_blank" rel="sponsored noopener">
       <%= image_tag @creative.small_image.cloudfront_url, border: 0, height: 55, width: 55, class: "cf-img", alt: @creative.name rescue nil %>
     </a>
-  <a data-href="campaign_url" class="cf-text" target="_blank" rel="sponsored noopener">
+    <a data-href="campaign_url" class="cf-text" target="_blank" rel="sponsored noopener">
       <strong><%= @creative.headline %></strong>
       <span><%= @creative.body %></span>
       <img data-src="impression_url" alt="">
     </a>
-  <button type="button" data-behavior="close">
-    <span aria-hidden="true">✕</span>
-  </button>
-</div>
+    <button type="button" data-behavior="close">
+      <span aria-hidden="true">✕</span>
+    </button>
+  </div>
 <% end %>

--- a/app/views/ad_templates/@responsive_footer/show.html.erb
+++ b/app/views/ad_templates/@responsive_footer/show.html.erb
@@ -1,15 +1,15 @@
 <% cache_if @campaign.persisted? && @creative.persisted?, [@campaign, @creative] do %>
-  <div id="cf">
-    <a data-href="campaign_url" class="cf-img-wrapper" target="_blank" rel="nofollow noopener">
+<div id="cf">
+  <a data-href="campaign_url" class="cf-img-wrapper" target="_blank" rel="sponsored noopener">
       <%= image_tag @creative.small_image.cloudfront_url, border: 0, height: 55, width: 55, class: "cf-img", alt: @creative.name rescue nil %>
     </a>
-    <a data-href="campaign_url" class="cf-text" target="_blank" rel="nofollow noopener">
+  <a data-href="campaign_url" class="cf-text" target="_blank" rel="sponsored noopener">
       <strong><%= @creative.headline %></strong>
       <span><%= @creative.body %></span>
       <img data-src="impression_url" alt="">
     </a>
-    <button type="button" data-behavior="close">
-      <span aria-hidden="true">✕</span>
-    </button>
-  </div>
+  <button type="button" data-behavior="close">
+    <span aria-hidden="true">✕</span>
+  </button>
+</div>
 <% end %>

--- a/app/views/ad_templates/bottom-bar/show.html.erb
+++ b/app/views/ad_templates/bottom-bar/show.html.erb
@@ -1,11 +1,11 @@
 <% cache_if @campaign.persisted? && @creative.persisted?, [@campaign, @creative] do %>
   <div id="cf">
     <span class="cf-wrapper">
-      <a data-href="campaign_url" class="cf-text" target="_blank" rel="nofollow noopener">
+      <a data-href="campaign_url" class="cf-text" target="_blank" rel="sponsored noopener">
         <strong><%= @creative.headline %></strong>
         <span><%= @creative.body %></span>
       </a>
-      <a href="https://codefund.io" data-target="powered_by_url" class="cf-powered-by" target="_blank" rel="nofollow noopener">
+      <a href="https://codefund.io" data-target="powered_by_url" class="cf-powered-by" target="_blank" rel="sponsored noopener">
         <em>ethical</em> ad by CodeFund
         <img data-src="impression_url" alt="">
       </a>

--- a/app/views/ad_templates/centered/show.html.erb
+++ b/app/views/ad_templates/centered/show.html.erb
@@ -2,11 +2,11 @@
   <div id="cf">
     <div class="cf-wrapper">
       <div class="cf-header">Proudly sponsored by</div>
-      <a data-href="campaign_url" class="cf-text" target="_blank" rel="nofollow noopener">
+      <a data-href="campaign_url" class="cf-text" target="_blank" rel="sponsored noopener">
         <strong><%= @creative.headline %></strong>
         <span><%= @creative.body %></span>
       </a>
-      <a href="https://codefund.io" data-target="powered_by_url" class="cf-powered-by" target="_blank" rel="nofollow noopener">
+      <a href="https://codefund.io" data-target="powered_by_url" class="cf-powered-by" target="_blank" rel="sponsored noopener">
         <em>ethical</em> ad by CodeFund
         <img data-src="impression_url" alt="">
       </a>

--- a/app/views/ad_templates/default/show.html.erb
+++ b/app/views/ad_templates/default/show.html.erb
@@ -2,7 +2,7 @@
   <div id="cf">
     <span>
       <span class="cf-wrapper">
-        <a data-href="campaign_url" target="_blank" rel="nofollow noopener">
+        <a data-href="campaign_url" target="_blank" rel="sponsored noopener">
           <span class="cf-img-wrapper">
             <%= image_tag @creative.large_image.cloudfront_url, border: 0, height: 100, width: 130, class: "cf-img", alt: @creative.name rescue nil %>
           </span>
@@ -11,7 +11,7 @@
             <span><%= @creative.body %></span>
           </span>
         </a>
-        <a href="https://codefund.io" data-target="powered_by_url" class="cf-powered-by" target="_blank" rel="nofollow noopener">
+        <a href="https://codefund.io" data-target="powered_by_url" class="cf-powered-by" target="_blank" rel="sponsored noopener">
           <em>ethical</em> ad by CodeFund
           <img data-src="impression_url" alt="">
         </a>

--- a/app/views/ad_templates/docsify/show.html.erb
+++ b/app/views/ad_templates/docsify/show.html.erb
@@ -2,7 +2,7 @@
   <div id="cf">
     <div class="cf-wrapper">
       <div class="clearfix">
-        <a data-href="campaign_url" target="_blank" rel="nofollow noopener">
+        <a data-href="campaign_url" target="_blank" rel="sponsored noopener">
           <span class="cf-img-wrapper">
             <%= image_tag @creative.small_image.cloudfront_url, width: 65, height: 65, class: "cf-img", alt: @creative.name rescue nil %>
           </span>
@@ -12,7 +12,7 @@
           </span>
         </a>
       </div>
-      <a href="https://codefund.io" data-target="powered_by_url" class="cf-powered-by" target="_blank" rel="nofollow noopener">
+      <a href="https://codefund.io" data-target="powered_by_url" class="cf-powered-by" target="_blank" rel="sponsored noopener">
         <em>ethical</em> ad by CodeFund
         <img data-src="impression_url" alt="">
       </a>

--- a/app/views/ad_templates/horizontal/show.html.erb
+++ b/app/views/ad_templates/horizontal/show.html.erb
@@ -1,11 +1,11 @@
 <% cache_if @campaign.persisted? && @creative.persisted?, [@campaign, @creative] do %>
   <div id="cf">
     <span class="cf-wrapper">
-      <a data-href="campaign_url" class="cf-text" target="_blank" rel="nofollow noopener">
+      <a data-href="campaign_url" class="cf-text" target="_blank" rel="sponsored noopener">
         <strong><%= @creative.headline %></strong>
         <span><%= @creative.body %></span>
       </a>
-      <a href="https://codefund.io" data-target="powered_by_url" class="cf-powered-by" target="_blank" rel="nofollow noopener">
+      <a href="https://codefund.io" data-target="powered_by_url" class="cf-powered-by" target="_blank" rel="sponsored noopener">
         <em>ethical</em> ad by CodeFund
         <img data-src="impression_url" alt="">
       </a>

--- a/app/views/ad_templates/image-centered/show.html.erb
+++ b/app/views/ad_templates/image-centered/show.html.erb
@@ -1,7 +1,7 @@
 <% cache_if @campaign.persisted? && @creative.persisted?, [@campaign, @creative] do %>
   <div id="cf">
     <span class="cf-wrapper">
-      <a data-href="campaign_url"target="_blank" rel="nofollow noopener">
+      <a data-href="campaign_url"target="_blank" rel="sponsored noopener">
         <span class="cf-img-wrapper">
           <%= image_tag @creative.large_image.cloudfront_url, border: 0, height: 100, width: 130, class: "cf-img", alt: @creative.name rescue nil %>
         </span>
@@ -10,7 +10,7 @@
           <span><%= @creative.body %></span>
         </span>
       </a>
-      <a href="https://codefund.io" data-target="powered_by_url" class="cf-powered-by" target="_blank" rel="nofollow noopener">
+      <a href="https://codefund.io" data-target="powered_by_url" class="cf-powered-by" target="_blank" rel="sponsored noopener">
         <em>ethical</em> ad by CodeFund
         <img data-src="impression_url" alt="">
       </a>

--- a/app/views/ad_templates/image-only/show.html.erb
+++ b/app/views/ad_templates/image-only/show.html.erb
@@ -2,10 +2,10 @@
   <div id="cf">
     <span class="cf-wrapper">
       <div class="cf-header">supported by</div>
-      <a data-href="campaign_url" class="cf-img-wrapper" target="_blank" rel="nofollow noopener">
+      <a data-href="campaign_url" class="cf-img-wrapper" target="_blank" rel="sponsored noopener">
         <%= image_tag @creative.small_image.cloudfront_url, height: 150, width: 150, class: "cf-img", alt: @creative.name rescue nil %>
       </a>
-      <a href="https://codefund.io" data-target="powered_by_url" class="cf-powered-by" target="_blank" rel="nofollow noopener">
+      <a href="https://codefund.io" data-target="powered_by_url" class="cf-powered-by" target="_blank" rel="sponsored noopener">
         <em>ethical</em> ad by CodeFund
         <img data-src="impression_url" alt="">
       </a>

--- a/app/views/ad_templates/media/show.html.erb
+++ b/app/views/ad_templates/media/show.html.erb
@@ -1,18 +1,18 @@
 <% cache_if @campaign.persisted? && @creative.persisted?, [@campaign, @creative] do %>
   <div id="cf">
     <span class="cf-wrapper">
-      <a data-href="campaign_url" class="cf-img-wrapper" target="_blank" rel="nofollow noopener">
+      <a data-href="campaign_url" class="cf-img-wrapper" target="_blank" rel="sponsored noopener">
         <%= image_tag @creative.small_image.cloudfront_url, border: 0, height: 48, width: 48, class: "cf-img", alt: @creative.name rescue nil %>
       </a>
       <div class="cf-media-body">
-        <a data-href="campaign_url" class="cf-text" target="_blank" rel="nofollow noopener">
+        <a data-href="campaign_url" class="cf-text" target="_blank" rel="sponsored noopener">
           <strong><%= @creative.headline %></strong>
           <span>
             <%= @creative.body %>
             <span class="cf-link"><%= @creative.cta %></span>
           </span>
         </a>
-        <a href="https://codefund.io" data-target="powered_by_url" class="cf-powered-by" target="_blank" rel="nofollow noopener">
+        <a href="https://codefund.io" data-target="powered_by_url" class="cf-powered-by" target="_blank" rel="sponsored noopener">
           <em>ethical</em> ad by CodeFund
         </a>
         <img data-src="impression_url" alt="">

--- a/app/views/ad_templates/rectangle-narrow/show.html.erb
+++ b/app/views/ad_templates/rectangle-narrow/show.html.erb
@@ -2,7 +2,7 @@
   <div id="cf">
     <span>
       <span class="cf-wrapper">
-        <a data-href="campaign_url" target="_blank" rel="nofollow noopener">
+        <a data-href="campaign_url" target="_blank" rel="sponsored noopener">
           <span class="cf-img-wrapper">
             <%= image_tag @creative.small_image.cloudfront_url, border: 0, height: 100, width: 100, class: "cf-img", alt: @creative.name rescue nil %>
           </span>
@@ -11,7 +11,7 @@
             <span><%= @creative.body %></span>
           </span>
         </a>
-        <a href="https://codefund.io" data-target="powered_by_url" class="cf-powered-by" target="_blank" rel="nofollow noopener">
+        <a href="https://codefund.io" data-target="powered_by_url" class="cf-powered-by" target="_blank" rel="sponsored noopener">
           ads served ethically
           <img data-src="impression_url" alt="">
         </a>

--- a/app/views/ad_templates/sponsored-text/show.html.erb
+++ b/app/views/ad_templates/sponsored-text/show.html.erb
@@ -5,7 +5,7 @@
       <%= image_tag @creative.icon_image.cloudfront_url, height: 20, width: 20, class: "cf-img", style: "width: 20px; height: 20px;", alt: @creative.name rescue nil %>
       <b><%= @creative.headline %></b>
       <%= @creative.body %>
-      <a href="#" data-href="campaign_url" rel="nofollow noopener" target="_blank">
+      <a href="#" data-href="campaign_url" rel="sponsored noopener" target="_blank">
         <b><%= @creative.cta || "Learn more" %></b>
       </a>
     </span>
@@ -15,7 +15,7 @@
         data-target="powered_by_url"
         class="cf-powered-by"
         target="_blank"
-        rel="nofollow noopener"
+        rel="sponsored noopener"
         title="Ethical ads by CodeFund"
       >
         <svg width="10px" height="10px" viewBox="0 0 10 10" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/app/views/ad_templates/square/show.html.erb
+++ b/app/views/ad_templates/square/show.html.erb
@@ -1,7 +1,7 @@
 <% cache_if @campaign.persisted? && @creative.persisted?, [@campaign, @creative] do %>
   <div id="cf">
     <span class="cf-wrapper">
-      <a data-href="campaign_url" target="_blank" rel="nofollow noopener">
+      <a data-href="campaign_url" target="_blank" rel="sponsored noopener">
         <span class="cf-img-wrapper" >
           <%= image_tag @creative.large_image.cloudfront_url, class: "cf-img", alt: @creative.name rescue nil %>
         </span>
@@ -10,7 +10,7 @@
           <span><%= @creative.body %></span>
         </span>
       </a>
-      <a href="https://codefund.io" data-target="powered_by_url" class="cf-powered-by" target="_blank" rel="nofollow noopener">
+      <a href="https://codefund.io" data-target="powered_by_url" class="cf-powered-by" target="_blank" rel="sponsored noopener">
         <em>ethical</em> ad by CodeFund
         <img data-src="impression_url" alt="">
       </a>

--- a/app/views/ad_templates/text/show.html.erb
+++ b/app/views/ad_templates/text/show.html.erb
@@ -2,7 +2,7 @@
   <div id="cf">
     <b><%= @creative.headline %></b>
     <%= @creative.body %>
-    <a data-href="campaign_url" rel="nofollow noopener" target="_blank" onmouseenter="this.style.color='#1d6fa5'" onmouseleave="this.style.color='#3498db'">
+    <a data-href="campaign_url" rel="sponsored noopener" target="_blank" onmouseenter="this.style.color='#1d6fa5'" onmouseleave="this.style.color='#3498db'">
       <b><%= @creative.cta || "Learn more" %></b>
     </a>
     <img class="cf-hidden" data-src="impression_url" alt="">

--- a/app/views/ad_templates/vertical/show.html.erb
+++ b/app/views/ad_templates/vertical/show.html.erb
@@ -1,7 +1,7 @@
 <% cache_if @campaign.persisted? && @creative.persisted?, [@campaign, @creative] do %>
   <div id="cf">
     <span class="cf-wrapper">
-      <a data-href="campaign_url" target="_blank" rel="nofollow noopener">
+      <a data-href="campaign_url" target="_blank" rel="sponsored noopener">
         <span class="cf-img-wrapper">
           <%= image_tag @creative.small_image.cloudfront_url, height: 125, width: 125, border: 0, class: "cf-img", alt: @creative.name rescue nil %>
         </span>
@@ -10,7 +10,7 @@
           <span><%= @creative.body %></span>
         </span>
       </a>
-      <a href="https://codefund.io" data-target="powered_by_url" class="cf-powered-by" target="_blank" rel="nofollow noopener">
+      <a href="https://codefund.io" data-target="powered_by_url" class="cf-powered-by" target="_blank" rel="sponsored noopener">
         ads by CodeFund
         <img data-src="impression_url" alt="">
       </a>


### PR DESCRIPTION
Resolve issue #756.

All the instances of `nofollow` falling under `ad_templates` are now replaced with `sponsored`.

- [x] `app/views/ad_templates/*` => 14
- [ ] `app/views/campaigns/*` => 01
- [ ] `app/views_redesigned/campaigns/*` => 01
- [ ] `test/system/*` => 01
- [ ] `vendor/themes/*` => 20

