### PR TITLE
Makes session works without caching-dev.txt

### DIFF
--- a/config/initializers/sessions.rb
+++ b/config/initializers/sessions.rb
@@ -1,5 +1,7 @@
 # Using redis to manage sessions (same cache appliance as standard rails caching)
 # IMPORTANT: "expire_after" should match "timeout_in" config in: config/initializers/devise.rb
-Rails.application.config.session_store ActionDispatch::Session::CacheStore,
-  key: "_code_fund_ads_session",
-  expire_after: 2.weeks
+unless Rails.application.config.cache_store == :null_store
+  Rails.application.config.session_store ActionDispatch::Session::CacheStore,
+    key: "_code_fund_ads_session",
+    expire_after: 2.weeks
+end


### PR DESCRIPTION
## Type of PR

- [ ] feature
- [ ] enhancement
- [x] bug fix
- [ ] other

## Description

[In case of absence of `caching-dev.txt`](https://github.com/gitcoinco/code_fund_ads/blob/master/config/environments/development.rb#L24)

[cache_store initializes as :null_store](https://github.com/gitcoinco/code_fund_ads/blob/master/config/environments/development.rb#L39)

[and later when it uses as session store](https://github.com/gitcoinco/code_fund_ads/blob/master/config/initializers/sessions.rb#L3)

it simply disables Rails `session` functionality. As a result there is no way to do almost all actions which relies on Rails security csrf mechanism.

## Checklist

- [x] My code follows the style guidelines of this project & the tests are passing
- [x] I have performed a self-review of my own code
- [x] I have requested a review from another developer(s)